### PR TITLE
css: use misc color for menu background

### DIFF
--- a/Material-Ocean/user.css
+++ b/Material-Ocean/user.css
@@ -147,3 +147,8 @@ a.main-collectionLinkButton-collectionLinkButton.main-collectionLinkButton-selec
 .main-createPlaylistButton-button:hover {
   background-color: var(--spice-button) !important;
 }
+
+/* Context Menu */
+.main-contextMenu-menu {
+  background-color: var(--spice-misc) !important;
+}


### PR DESCRIPTION
Because:

- The red color is too bright and it does not fit with the theme
- It looks ugly

 Red                            |            Dark
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/45706694/135702914-435364ff-78bc-4277-89d3-fb108acd77db.png "Earlier Red")  | ![image](https://user-images.githubusercontent.com/45706694/135703254-bc0c2ef3-d227-4d18-a6bf-cf7c2cdf6477.png "Darken Now")
